### PR TITLE
Fix logging of Error objects

### DIFF
--- a/lib/slack-winston.js
+++ b/lib/slack-winston.js
@@ -46,9 +46,16 @@ Slack.prototype.name = 'Slack'
 //
 Slack.prototype._request = function (options, callback) {
   options = options || {}
-
   options.method = 'POST'
-  options.params.meta = Object.keys(options.params.meta).length ? JSON.stringify(options.params.meta, null, 2) : ''
+  var meta = options.params.meta
+  if (options.params.meta instanceof Error) {
+    options.params.message = options.params.meta.message
+    options.params.meta = meta.stack
+  } else if (Object.keys(options.params.meta).length) {
+    options.params.meta = JSON.stringify(meta, null, 2)
+  } else {
+    options.params.meta = ''
+  }  
   options.qs = {
     token: this.options.token,
     channel: this.options.channel


### PR DESCRIPTION
Current implementation hides logging of error objects because Object.keys(new Error('my error')).length is 0.
