### PR TITLE
Fixed channel override

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Many options can be seen in the [Slack API docs](https://api.slack.com/methods/c
 * __level:__ Level of messages that this transport should log
 * __silent:__ If true, will not log messages
 * __token:__ Required. Slack incoming webhook token
-* __channel:__ Required. Channel of chat (e.g. "#foo" or "foo")
+* __channel:__ Required. Channel of chat (e.g. "#foo" or "@foo")
 * __domain:__ Required. Domain of Slack (e.g. "foo" if "foo.slack.com")
 * __username:__ Username of the incoming webhook Slack bot (defaults to "Winston")
 * __icon_emoji:__ Icon of bot (defaults to :tophat: `:tophat:`)

--- a/lib/slack-winston.js
+++ b/lib/slack-winston.js
@@ -17,7 +17,6 @@ var Slack = exports.Slack = function (options) {
 
   if (!options.domain) throw new Error('Must have a domain option set.')
   if (!options.token) throw new Error('Must have a token option set.')
-  if (!options.channel) throw new Error('Must have a channel option set.')
 
   this.name = 'Slack'
   this.options = _.defaults(options || {}, {
@@ -50,8 +49,7 @@ Slack.prototype._request = function (options, callback) {
   options.method = 'POST'
   options.params.meta = Object.keys(options.params.meta).length ? JSON.stringify(options.params.meta, null, 2) : ''
   options.qs = {
-    token: this.options.token,
-    channel: this.options.channel
+    token: this.options.token
   }
   options.body = JSON.stringify({
     text: this.options.message ? _.template(this.options.message, options.params, {
@@ -63,7 +61,8 @@ Slack.prototype._request = function (options, callback) {
     attachments: this.options.attachments,
     unfurl_links: this.options.unfurl_links,
     icon_url: this.options.icon_url,
-    icon_emoji: this.options.icon_emoji
+    icon_emoji: this.options.icon_emoji,
+    channel: this.options.channel
   })
   options.json = true
   options.url = util.format('https://%s.slack.com/services/hooks/incoming-webhook', this.options.domain)


### PR DESCRIPTION
Fixed channel overwrite not working, the channel parameter must be passed in the body, not the query string. The channel is also optional since a default channel is required when setting up a Slack webhook.

Also updated the documentation. The channel name must either be a normal channel prefixed with # or a direct message to a user @username.
