### PR TITLE
Add possibility to use function for attachments.

### DIFF
--- a/lib/slack-winston.js
+++ b/lib/slack-winston.js
@@ -72,7 +72,7 @@ Slack.prototype._request = function (options, callback) {
     username: this.options.username,
     parse: this.options.parse,
     link_names: this.options.link_names,
-    attachments: this.options.attachments,
+    attachments: _.isFunction(this.options.attachments) ? this.options.attachments(options.params, meta) : this.options.attachments,
     unfurl_links: this.options.unfurl_links,
     icon_url: this.options.icon_url,
     icon_emoji: this.options.icon_emoji


### PR DESCRIPTION
Params and original meta-object are passed as arguments.
Example:

```
attachments: function (params, meta) {
  return [
    {
      "fallback": params.message,
      "color": params.level === 'info' ? 'good' : ( params.level === 'error' ? 'danger' : 'warning' ),
      "title": params.message,
      "fields": [
        {
          "title": 'Field 1',
          "value": meta.field1
        }
      ]
    }
  ];
}
```
