### PR TITLE
meta might be null or undefined (for example when using with winston …

### DIFF
--- a/lib/slack-winston.js
+++ b/lib/slack-winston.js
@@ -51,7 +51,9 @@ Slack.prototype._request = function (options, callback) {
 
   options.method = 'POST';
   var meta = options.params.meta;
-  if (options.params.meta instanceof Error) {
+  if (!meta) {
+    options.params.meta = '';
+  } else if (options.params.meta instanceof Error) {
     options.params.message = options.params.meta.message;
     options.params.meta = meta.stack;
   } else if (Object.keys(options.params.meta).length) {


### PR DESCRIPTION
…logger as a transporter).

In this case the code crashes at
Object.keys(options.params.meta) with "Cannot convert undefined or null to object"
This change fix this issue without changing the behavior of the code