### PR TITLE
Fixed the value of `json` in the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ var slackWinston = require('slack-winston').Slack
 var options = {
   domain: 'my-domain',
   token: 'my-slack-incoming-webhook-token',
+  webhook_url: 'my-slack-incoming-webhook-url',
   channel: 'general',
   level: 'warn'
 }
@@ -46,6 +47,7 @@ Many options can be seen in the [Slack API docs](https://api.slack.com/methods/c
 * __level:__ Level of messages that this transport should log
 * __silent:__ If true, will not log messages
 * __token:__ Required. Slack incoming webhook token
+* __webhook_url:__ Required. Slack incoming webhook url.
 * __channel:__ Required. Channel of chat (e.g. "#foo" or "@foo")
 * __domain:__ Required. Domain of Slack (e.g. "foo" if "foo.slack.com")
 * __username:__ Username of the incoming webhook Slack bot (defaults to "Winston")

--- a/lib/slack-winston.js
+++ b/lib/slack-winston.js
@@ -79,7 +79,7 @@ Slack.prototype._request = function (options, callback) {
     icon_url: this.options.icon_url,
     icon_emoji: this.options.icon_emoji
   });
-  options.json = true;
+  options.json = false;
   if(!this.options.webhook_url) {
     options.url = util.format('https://%s.slack.com/services/hooks/incoming-webhook', this.options.domain);
   } else {


### PR DESCRIPTION
The value was set to true, but the body sent was a string, not a json, and that was causing a 'bad-parameters' 400 error.

Also, updated the `README` to include the `webhook_url`in the creation options.

As a side note, it'd be good to restructure the README, since some of the parameters listed for the options are not entirely required (token -it was so difficult to try to find a 'incoming webhook token' given that there are none-, channel, etc...).