### PR TITLE
Added requests queue, reaction on Slack rate limit + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ lib-cov
 *.pid
 *.gz
 .DS_store
+.idea
 
 pids
 logs

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Many options can be seen in the [Slack API docs](https://api.slack.com/methods/c
 * __username:__ Username of the incoming webhook Slack bot (defaults to "Winston")
 * __icon_emoji:__ Icon of bot (defaults to :tophat: `:tophat:`)
 * __message:__ [lodash templates](http://lodash.com/docs#template). Gets passed the `{{message}}`, `{{level}}`, and `{{meta}}` as a JSON string. If not specified, it will print a default of `{{message}}\n\n{{meta}}`.  **Note that this gets sent as the `text` field in the payload per Slack requirements.**
-
+* __queueDelay:__ Delay time (ms) between messages in queue (defaults to 500)
 
 ## Credits
 

--- a/lib/slack-winston.js
+++ b/lib/slack-winston.js
@@ -4,7 +4,9 @@ var util = require('util')
 , winston = require('winston')
 , request = require('request')
 , Stream = require('stream').Stream
-, _ = require('lodash');
+, _ = require('lodash')
+, queue = require('async').queue
+, retry = require('async').retry;
 
 //
 // ### function Slack (options)
@@ -20,7 +22,6 @@ var Slack = exports.Slack = function (options) {
     if (!options.token) throw new Error('Must have a token option set.');
   }
 
-
   this.name = 'Slack';
   this.options = _.defaults(options || {}, {
     username: 'Winston',
@@ -29,7 +30,49 @@ var Slack = exports.Slack = function (options) {
     attachments: null,
     unfurl_links: null,
     icon_url: false,
-    icon_emoji: ':tophat:'
+    icon_emoji: ':tophat:',
+    queueDelay: 500
+  });
+
+  var self = this;
+
+  var rateLimitMessage = 'It was sending a lot of messages';
+
+  this.requestsQueue = queue(function (task, callback) {
+    var retryInterval = 60000;
+
+    retry(
+      {
+        times: 3,
+        interval: function() {
+          return retryInterval;
+        },
+        errorFilter: function (err) {
+          return err.message === rateLimitMessage;
+        }
+      },
+      function (retryCb) {
+        request(task.options, function (err, res) {
+          if (err) {
+            retryCb(err, null);
+          } else if (res.statusCode === 429) { // handle rate limit
+            var retryAfter = parseInt(res.headers['retry-after'], 10);
+            var headerSecs = _.isInteger(retryAfter) ? retryAfter : 60;
+
+            retryInterval = headerSecs * 1000;
+
+            retryCb(new Error(rateLimitMessage), null);
+          } else {
+            retryCb(null, res);
+          }
+        });
+      },
+      function (err, res) {
+        // send next message with delay
+        setTimeout(function () { callback(err, res) }, self.options.queueDelay);
+      }
+    );
+
   });
 };
 
@@ -79,15 +122,16 @@ Slack.prototype._request = function (options, callback) {
     icon_url: this.options.icon_url,
     icon_emoji: this.options.icon_emoji
   });
+
   options.json = false;
+
   if(!this.options.webhook_url) {
     options.url = util.format('https://%s.slack.com/services/hooks/incoming-webhook', this.options.domain);
   } else {
     options.url = this.options.webhook_url;  
   }
   
-
-  return request(options, callback);
+  return this.requestsQueue.push({options: options}, callback);
 };
 
 //
@@ -119,7 +163,7 @@ Slack.prototype.log = function (level, msg, meta, callback) {
 
   this._request(options, function (err, res) {
 
-    if (res && res.statusCode !== 200) {
+    if (!err && res && res.statusCode !== 200) {
       err = new Error('winston: slack: HTTP Status Code: ' + res.statusCode);
     }
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.7",
   "description": "A Slack transport for winston",
   "author": "Nick Baugh <niftylettuce@gmail.com>",
+  "scripts": {
+    "test": "mocha --timeout 5000 test/"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/niftylettuce/slack-winston.git"
@@ -17,10 +20,14 @@
     "flatiron"
   ],
   "dependencies": {
-    "request": "~2.78.0",
-    "lodash": "~4.16.6"
+    "async": "^2.4.1",
+    "lodash": "~4.16.6",
+    "request": "~2.78.0"
   },
   "devDependencies": {
+    "chai": "^4.0.2",
+    "mocha": "^3.4.2",
+    "nock": "^9.0.13",
     "winston": "~2.3"
   },
   "peerDependencies": {

--- a/test/slack-winston.spec.js
+++ b/test/slack-winston.spec.js
@@ -1,0 +1,54 @@
+var expect = require('chai').expect,
+  Slack = require('../lib/slack-winston').Slack,
+  nock = require('nock');
+
+
+var config = {
+  webhook_url: 'http://slack.com/',
+  channel: '#some-channel',
+  username: 'My Logger',
+  icon_emoji: ':smiling_imp:',
+  message: '{{message}}\n\n```{{meta}}```'
+};
+
+describe('Slack', function () {
+  var transport;
+
+  beforeEach(function () {
+    transport = new Slack(config);
+  });
+
+  it('should log to Slack', function(done) {
+    nock('http://slack.com')
+      .post('/')
+      .reply(200);
+
+    transport.log('info', 'TestMessage', {}, function(err, res) {
+      expect(err).to.be.eq(null);
+      expect(res).to.be.eq(true);
+
+      done();
+    });
+  });
+
+  it('should resend message in rate limit case', function(done) {
+    nock('http://slack.com')
+      .post('/')
+      .reply(429, '', { 'Retry-After': '1' });
+
+    nock('http://slack.com')
+      .post('/')
+      .reply(200);
+
+    var startedAt = new Date();
+
+    transport.log('info', 'TestMessage', {}, function(err, res) {
+      expect(err).to.be.eq(null);
+      expect(res).to.be.eq(true);
+
+      expect(Date.now() - startedAt.valueOf()).to.be.above(1000 + 500);
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
I faced Slack rate limit when my app has out of control and sent error messages very intensively. Incoming webhook has been disabled by Slack automatically with a warning message on my email. Yes, it was problems with my app, but such case is fairly probable. 

I offer a queue for requests, and reaction on 429 HTTP Response (Rate limit - https://api.slack.com/docs/rate-limits). Also, I wrote a few of tests. 