### PR TITLE
Allow multiple transports within the same logger

### DIFF
--- a/lib/slack-winston.js
+++ b/lib/slack-winston.js
@@ -22,8 +22,8 @@ var Slack = exports.Slack = function (options) {
     if (!options.token) throw new Error('Must have a token option set.');
   }
 
-  this.name = 'Slack';
   this.options = _.defaults(options || {}, {
+    name: 'Slack',
     username: 'Winston',
     parse: null,
     link_names: null,


### PR DESCRIPTION
Use-case: I want to log all logs of level "info" to one logging channel in slack, and I also want log level "error" go to another channel where I can leave alerts on at all times to be notified of something critical.

The following configuration was causing: "Error: Transport already attached: Slack, assign a different name"

```js
winston.configure({ transports: [
  // Slack logging
  new (slackWinston)({
    name: 'slack-logs',
    domain: 'my-domain',
    token: 'my-slack-incoming-webhook-token',
    webhook_url: 'my-slack-incoming-webhook-url',
    channel: '#app-logs',
    level: 'info'
  }),
  // Slack error reporting:
  new (slackWinston)({
    name: 'slack-errors',
    domain: 'my-domain',
    token: 'my-slack-incoming-webhook-token',
    webhook_url: 'my-slack-incoming-webhook-url',
    channel: '#app-errors',
    level: 'error'
  })
]})
```

This change allows the user to assign a `name` to the transport, and have more than one attached to the same logger.