### PR TITLE
Perfer attachments to process metadata if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Many options can be seen in the [Slack API docs](https://api.slack.com/methods/c
 * __icon_emoji:__ Icon of bot (defaults to :tophat: `:tophat:`)
 * __message:__ [lodash templates](http://lodash.com/docs#template). Gets passed the `{{message}}`, `{{level}}`, and `{{meta}}` as a JSON string. If not specified, it will print a default of `{{message}}\n\n{{meta}}`.  **Note that this gets sent as the `text` field in the payload per Slack requirements.**
 * __queueDelay:__ Delay time (ms) between messages in queue (defaults to 500)
+* __attachments:__ A function which can be used to format metadata in using the slack "attachments" property for slack cards (pretty formatting). If this is not provided, log meta data will be passed to slack in the main text body and output as plain text.
 
 ## Credits
 

--- a/lib/slack-winston.js
+++ b/lib/slack-winston.js
@@ -109,15 +109,23 @@ Slack.prototype._request = function (options, callback) {
       token: this.options.token
     };
   }
+
+  // Process metadata with the "attachments" function if we have one, otherwise attach it to the main text
+  var text = this.options.attachments
+    ? options.params.message
+    : options.params.message + (options.params.meta ? '\n\n' + options.params.meta : '');
+
+  var attachments = _.isFunction(this.options.attachments)
+    ? this.options.attachments(options.params, meta)
+    : this.options.attachments;
+
   options.body = JSON.stringify({
     channel: this.options.channel,
-    text: this.options.message ? _.template(this.options.message, {
-      interpolate: /\{\{(.*?)\}\}/g
-    })(options.params) : options.params.message + (options.params.meta ? '\n\n' + options.params.meta : ''),
+    text: text,
     username: this.options.username,
     parse: this.options.parse,
     link_names: this.options.link_names,
-    attachments: _.isFunction(this.options.attachments) ? this.options.attachments(options.params, meta) : this.options.attachments,
+    attachments: attachments,
     unfurl_links: this.options.unfurl_links,
     icon_url: this.options.icon_url,
     icon_emoji: this.options.icon_emoji


### PR DESCRIPTION
As promised in https://github.com/gradient/slack-winston/commit/3f8703dc46726410555b7640954d39125cd02a0d#commitcomment-26916636, here's the PR for the attachments function.

If an "attachments" function is configured, use that to process and output the metadata. Otherwise attach it to the message as previously done.

**Note: This is an API change and will impact how existing implementations may function.**