### PR TITLE
Change module default options and remove token requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 > **NOTE**: This package was created because `winston-slack` did not have similar code
 structure to `winston-hipchat` (switched from using HipChat &rarr; Slack and wanted consistency).
 
+**API change notice:** 1.x has made potentially breaking changes to the modules options. The `token` field is no longer required as the slack API no longer uses it. The username and emoji field now function differently. See the [usage](#usage) section for more details.
 
 ## Index
 
@@ -46,12 +47,12 @@ Many options can be seen in the [Slack API docs](https://api.slack.com/methods/c
 
 * __level:__ Level of messages that this transport should log
 * __silent:__ If true, will not log messages
-* __token:__ Required. Slack incoming webhook token
-* __webhook_url:__ Required. Slack incoming webhook url.
+* __webhook_url:__ Required. Slack incoming webhook url, _if your webhook integration is old for some reason then you may prefer to use the domain and token approach instead_.
+* __domain:__ Required if webhook_url is not provided. Domain of Slack (e.g. "foo" if "foo.slack.com")
+* __token:__ Required if webhook_url is not provided. The token provided by slack
 * __channel:__ Required. Channel of chat (e.g. "#foo" or "@foo")
-* __domain:__ Required. Domain of Slack (e.g. "foo" if "foo.slack.com")
-* __username:__ Username of the incoming webhook Slack bot (defaults to "Winston")
-* __icon_emoji:__ Icon of bot (defaults to :tophat: `:tophat:`)
+* __username:__ Username of the incoming webhook Slack bot, if this is not set then slack will use the integration (webhook) configuration settings.
+* __icon_emoji:__ Icon of bot, if this is not set then slack will use the integration (webhook) configuration settings.
 * __message:__ [lodash templates](http://lodash.com/docs#template). Gets passed the `{{message}}`, `{{level}}`, and `{{meta}}` as a JSON string. If not specified, it will print a default of `{{message}}\n\n{{meta}}`.  **Note that this gets sent as the `text` field in the payload per Slack requirements.**
 * __queueDelay:__ Delay time (ms) between messages in queue (defaults to 500)
 


### PR DESCRIPTION
There are two changes in the PR which I'd be happy to split into 2 commits if needed.

1. The `token` field is only required if the webhook_url is not set, I've updated the documentation to reflect this. The token field isn't given by slack when creating a wehook anymore so this could be a bit confusing otherwise.
2. The username and icon_emoji now default to null. This means they will default to using the integrations settings. Previously if you wanted to use an icon (for example), the icon_emoji flag would overwrite it due to the default being set in this module. Passing null would have no effect. This seems sensible to change for the username as well to allow someone to manage the settings from the slack integration, making this module a bit more flexible.

I've added an API change notice at the top of the readme with the assumption that the module will bump to 1.x because of the API change. If this is incorrect I'm happy to correct it, likewise I've also ticked "Allow edits from maintainers" if you'd prefer to change the copy completely without waiting for me :smile:

These changes were promised after discussion on - https://github.com/gradient/slack-winston/commit/3f8703dc46726410555b7640954d39125cd02a0d#commitcomment-26916636 for future reference.

Ps: great module and some nice code in here, thanks for publishing it.