### PR TITLE
Update request and lodash versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   ],
   "dependencies": {
     "async": "^2.4.1",
-    "lodash": "~4.16.6",
-    "request": "~2.78.0"
+    "lodash": "^4.17.5",
+    "request": "^2.85.0"
   },
   "devDependencies": {
     "chai": "^4.0.2",


### PR DESCRIPTION
According to snyk, there are Prototype Pollution vulnerability in hoek@2.16.3 (dependency of request@2.78.0) and lodash@4.16.6, and also Uninitialized Memory Exposure vulnerability in tunnel-agent@0.4.3 (dependency of request@2.78.0).

I've update `request` and `lodash` to latest versions, which seems to have those vulnerabilities fixed.
Also, changed `~` to `^` 'cause there would doubtfully be braking changes in minor updates of the libs.

Tests are running, I've also tested it on real Slack integration - works OK.